### PR TITLE
Update eclipse compiler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,22 +181,6 @@
 	</repositories>
 	<pluginRepositories>
 		<pluginRepository>
-			<id>njol-repo</id>
-			<url>http://maven.njol.ch/repo</url>
-		</pluginRepository>
-		<pluginRepository>
-			<id>sk89q-repo</id>
-			<url>http://maven.sk89q.com/repo</url>
-		</pluginRepository>
-		<pluginRepository>
-			<id>techcable-repo</id>
-			<url>http://repo.techcable.net/content/repositories/public</url>
-		</pluginRepository>
-		<pluginRepository>
-			<id>spigot-repo</id>
-			<url>http://hub.spigotmc.org/nexus/content/groups/public</url>
-		</pluginRepository>
-		<pluginRepository>
 			<id>lifemc-repo</id>
 			<url>http://lifemcserver.com</url>
 		</pluginRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,28 @@
 			<url>http://lifemcserver.com</url>
 		</repository>
 	</repositories>
+	<pluginRepositories>
+		<pluginRepository>
+			<id>njol-repo</id>
+			<url>http://maven.njol.ch/repo</url>
+		</pluginRepository>
+		<pluginRepository>
+			<id>sk89q-repo</id>
+			<url>http://maven.sk89q.com/repo</url>
+		</pluginRepository>
+		<pluginRepository>
+			<id>techcable-repo</id>
+			<url>http://repo.techcable.net/content/repositories/public</url>
+		</pluginRepository>
+		<pluginRepository>
+			<id>spigot-repo</id>
+			<url>http://hub.spigotmc.org/nexus/content/groups/public</url>
+		</pluginRepository>
+		<pluginRepository>
+			<id>lifemc-repo</id>
+			<url>http://lifemcserver.com</url>
+		</pluginRepository>
+	</pluginRepositories>
 	<build>
 		<finalName>${project.artifactId}</finalName>
 		<resources>

--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@
 		          <dependency>
                     <groupId>org.eclipse.jdt.core.compiler</groupId>
                     <artifactId>ecj</artifactId>
-                    <version>4.6.1</version>
+                    <version>4.11RC1</version>
                   </dependency>
 		        </dependencies>
 			</plugin>


### PR DESCRIPTION
Maven central build is too old, downloaded a custom one from the eclipse downloads page.

# Changes made in this Pull Request
Updated eclipse java compiler from 4.6.1 to 4.11RC1 (latest beta release)

# Reason of the above changes are
The maven central build is too old

# Other informations about this Pull Request
The custom one is from the www.lifemcserver.com repository.
