### PR TITLE
Update the eclipse java compiler version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -575,7 +575,7 @@
                     <dependency>
                         <groupId>org.eclipse.jdt.core.compiler</groupId>
                         <artifactId>ecj</artifactId>
-                        <version>4.12M1</version>
+                        <version>4.12M3</version>
                     </dependency>
                 </dependencies>
             </plugin>


### PR DESCRIPTION
# Changes made in this Pull Request
Updated the eclipse java compiler version.

# Reason of the above changes are
Since we use beta releases (e.g 4.12M1, M3, where M means a beta release) we should always use latest version of the compiler.

# Other informations about this Pull Request
We use compiler to compile our code. We should _not_ use beta releases when releasing stable versions such as 2.2.15, 2.2.16 (e.g _not_ 2.2.13b).

Because if we use beta release of the compiler, then compiled code is _not stable_.

However, for 2.2.16, this version can be used. But in future, we should only use stable versions to avoid bugs.