### PR TITLE
Fix wrong javadoc comment on agent event

### DIFF
--- a/src/main/java/ch/njol/skript/agents/AgentEvent.kt
+++ b/src/main/java/ch/njol/skript/agents/AgentEvent.kt
@@ -27,8 +27,6 @@ package ch.njol.skript.agents
 /**
  * Represents a skript debugger event.
  *
- * It extends bukkit's event, but it's not used.
- *
  * @since 2.2-V13b
  */
 abstract class AgentEvent {


### PR DESCRIPTION
It was no longer extend bukkit's event class after the commit https://github.com/LifeMC/LifeSkript/commit/36b47f128d7e9871a607b44bba92070a0d0fd544#diff-173c1cc316518aed4a3d78128b984876

# Changes made in this Pull Request
Removed no longer relevant javadoc comment.

# Reason of the above changes are
It was no longer extend the mentioned class.

# Other informations about this Pull Request
N/A