### PR TITLE
Finally fix slow variable saving (resolves GH-82)

### DIFF
--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -204,6 +204,7 @@ public final class Skript extends JavaPlugin implements NonReflectiveAddon, List
      */
     @Nullable
     public static final Logger minecraftLogger = isBukkitRunning() ? Bukkit.getLogger() : null;
+    public static final boolean offlineUUIDSupported = Skript.methodExists(OfflinePlayer.class, "getUniqueId");
     @SuppressWarnings("null")
     private static final Collection<Closeable> closeOnDisable = Collections.synchronizedCollection(new ArrayList<>(100));
     private static final Collection<Closeable> closeOnEnable = Collections.synchronizedCollection(new ArrayList<>(100));

--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -59,6 +59,7 @@ import ch.njol.util.coll.iterator.CheckedIterator;
 import ch.njol.util.coll.iterator.EnumerationIterable;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.World;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;

--- a/src/main/java/ch/njol/skript/lang/Variable.java
+++ b/src/main/java/ch/njol/skript/lang/Variable.java
@@ -48,7 +48,6 @@ import ch.njol.util.coll.CollectionUtils;
 import ch.njol.util.coll.iterator.EmptyIterator;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
-import org.bukkit.OfflinePlayer;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
@@ -68,7 +67,6 @@ public final class Variable<T> implements Expression<T> {
     public static final String LOCAL_VARIABLE_TOKEN = "_";
     private static final String SINGLE_SEPARATOR_CHAR = ":";
     public static final String SEPARATOR = SINGLE_SEPARATOR_CHAR + SINGLE_SEPARATOR_CHAR;
-    private static final boolean uuidSupported = Skript.methodExists(OfflinePlayer.class, "getUniqueId");
     private static final Pattern SEPARATOR_PATTERN = Pattern.compile(SEPARATOR, Pattern.LITERAL);
     private static final Matcher SEPARATOR_PATTERN_MATCHER = SEPARATOR_PATTERN.matcher("");
     /**
@@ -309,7 +307,7 @@ public final class Variable<T> implements Expression<T> {
         if (SkriptConfig.enablePlayerVariableFix.value() && t instanceof Player) {
             final Player p = (Player) t;
             if (!p.isValid() && p.isOnline()) {
-                final Player player = uuidSupported ? Bukkit.getPlayer(p.getUniqueId()) : Bukkit.getPlayerExact(p.getName());
+                final Player player = Skript.offlineUUIDSupported ? Bukkit.getPlayer(p.getUniqueId()) : Bukkit.getPlayerExact(p.getName());
                 Variables.setVariable(key, player, event, local);
                 return player;
             }

--- a/src/main/java/ch/njol/skript/lang/Variable.java
+++ b/src/main/java/ch/njol/skript/lang/Variable.java
@@ -83,7 +83,7 @@ public final class Variable<T> implements Expression<T> {
     private final Variable<?> source;
 
     @SuppressWarnings("unchecked")
-    private Variable(final VariableString name, final Class<? extends T>[] types, final boolean local, final boolean list, final @Nullable Variable<?> source) {
+    private Variable(final VariableString name, final Class<? extends T>[] types, final boolean local, final boolean list, @Nullable final Variable<?> source) {
         assert name != null;
         assert types != null && types.length > 0;
 
@@ -169,7 +169,7 @@ public final class Variable<T> implements Expression<T> {
                     assert type != null;
                     if (type.isAssignableFrom(hint)) {
                         // Hint matches, use variable with exactly correct type
-                        return new Variable<>(vs, CollectionUtils.array(type), isLocal, isPlural, null);
+                        return new Variable<>(vs, CollectionUtils.array(type), true, isPlural, null);
                     }
                 }
 
@@ -178,17 +178,17 @@ public final class Variable<T> implements Expression<T> {
                     assert type != null;
                     if (Converters.converterExists(hint, type)) {
                         // Hint matches, even though converter is needed
-                        return new Variable<>(vs, CollectionUtils.array(type), isLocal, isPlural, null);
+                        return new Variable<>(vs, CollectionUtils.array(type), true, isPlural, null);
                     }
 
                     // Special cases
                     if (type.isAssignableFrom(World.class) && hint.isAssignableFrom(String.class)) {
                         // String->World conversion is weird spaghetti code
-                        return new Variable<>(vs, types, isLocal, isPlural, null);
+                        return new Variable<>(vs, types, true, isPlural, null);
                     }
                     if (type.isAssignableFrom(Player.class) && hint.isAssignableFrom(String.class)) {
                         // String->Player conversion is not available at this point
-                        return new Variable<>(vs, types, isLocal, isPlural, null);
+                        return new Variable<>(vs, types, true, isPlural, null);
                     }
                 }
 
@@ -236,7 +236,7 @@ public final class Variable<T> implements Expression<T> {
     }
 
     @Override
-    public String toString(final @Nullable Event e, final boolean debug) {
+    public String toString(@Nullable final Event e, final boolean debug) {
         if (e != null)
             return Classes.toString(get(e), name, debug); // Special handling for variables
         return '{' + (local ? "_" : "") + StringUtils.substring(name.toString(e, debug), 1, -1) + '}' + (debug ? "(as " + superType.getName() + ')' : "");
@@ -261,7 +261,7 @@ public final class Variable<T> implements Expression<T> {
         final String n = name.toString(e).toLowerCase(Locale.ENGLISH);
         if (n.endsWith(Variable.SEPARATOR + '*') != list) // prevents e.g. {%expr%} where "%expr%" ends with "::*" from returning a Map
             return null;
-        final Object val = !list ? convertIfOldPlayer(n, e, Variables.getVariable(n, e, local)) : Variables.getVariable(n, e, local);
+        final Object val = !list ? convertIfOldPlayer(n, e, local, Variables.getVariable(n, e, local)) : Variables.getVariable(n, e, local);
         if (val == null)
             return Variables.getVariable((local ? LOCAL_VARIABLE_TOKEN : "") + name.getDefaultVariableName().toLowerCase(Locale.ENGLISH), e, false);
         return val;
@@ -279,7 +279,7 @@ public final class Variable<T> implements Expression<T> {
         final String name = StringUtils.substring(this.name.toString(e), 0, -1).toLowerCase(Locale.ENGLISH);
         for (final Entry<String, ?> v : ((Map<String, ?>) val).entrySet()) {
             if (v.getKey() != null && v.getValue() != null) {
-                l.add(convertIfOldPlayer(name + v.getKey(), e, v.getValue() instanceof Map ? ((Map<String, ?>) v.getValue()).get(null) : v.getValue()));
+                l.add(convertIfOldPlayer(name + v.getKey(), e, local, v.getValue() instanceof Map ? ((Map<String, ?>) v.getValue()).get(null) : v.getValue()));
             }
         }
         return l.toArray();
@@ -304,7 +304,6 @@ public final class Variable<T> implements Expression<T> {
      * because the player object inside the variable will be a (kinda) dead variable
      * as a new player object has been created by the server.
      */
-    @SuppressWarnings("deprecation")
     @Nullable
     static final Object convertIfOldPlayer(final String key, final Event event, final boolean local, @Nullable final Object t) {
         if (SkriptConfig.enablePlayerVariableFix.value() && t instanceof Player) {
@@ -458,21 +457,21 @@ public final class Variable<T> implements Expression<T> {
     }
 
     @Nullable
-    private T getConverted(final Event e) {
+    private final T getConverted(final Event e) {
         assert !list;
         return Converters.convert(get(e), types);
     }
 
-    private T[] getConvertedArray(final Event e) {
+    private final T[] getConvertedArray(final Event e) {
         assert list;
         return Converters.convertArray((Object[]) get(e), types, superType);
     }
 
-    private void set(final Event e, final @Nullable Object value) {
+    private void set(final Event e, @Nullable final Object value) {
         Variables.setVariable(name.toString(e).toLowerCase(Locale.ENGLISH), value, e, local);
     }
 
-    private void setIndex(final Event e, final String index, final @Nullable Object value) {
+    private void setIndex(final Event e, final String index, @Nullable final Object value) {
         assert list;
         final String s = name.toString(e).toLowerCase(Locale.ENGLISH);
         assert s.endsWith("::*") : s + "; " + name;
@@ -489,7 +488,7 @@ public final class Variable<T> implements Expression<T> {
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
-    public final void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) throws UnsupportedOperationException {
+    public final void change(final Event e, @Nullable final Object[] delta, final ChangeMode mode) throws UnsupportedOperationException {
         switch (mode) {
             case DELETE:
                 set(e, null);
@@ -544,7 +543,7 @@ public final class Variable<T> implements Expression<T> {
                     if (mode == ChangeMode.REMOVE) {
                         if (o == null)
                             return;
-                        final ArrayList<String> rem = new ArrayList<>(); // prevents CMEs
+                        final List<String> rem = new ArrayList<>(); // prevents CMEs
                         for (final Object d : delta) {
                             for (final Entry<String, Object> i : o.entrySet()) {
                                 if (Relation.EQUAL.is(Comparators.compare(i.getValue(), d))) {
@@ -565,7 +564,7 @@ public final class Variable<T> implements Expression<T> {
                     } else if (mode == ChangeMode.REMOVE_ALL) {
                         if (o == null)
                             return;
-                        final ArrayList<String> rem = new ArrayList<>(); // prevents CMEs
+                        final List<String> rem = new ArrayList<>(); // prevents CMEs
                         for (final Entry<String, Object> i : o.entrySet()) {
                             for (final Object d : delta) {
                                 if (Relation.EQUAL.is(Comparators.compare(i.getValue(), d)))
@@ -635,7 +634,7 @@ public final class Variable<T> implements Expression<T> {
                         for (int i = 0; i < cs.length; i++)
                             cs2[i] = cs[i].isArray() ? cs[i].getComponentType() : cs[i];
 
-                        final ArrayList<Object> l = new ArrayList<>();
+                        final List<Object> l = new ArrayList<>();
                         for (final Object d : delta) {
                             final Object d2 = Converters.convert(d, cs2);
                             if (d2 != null)

--- a/src/main/java/ch/njol/skript/variables/DatabaseStorage.java
+++ b/src/main/java/ch/njol/skript/variables/DatabaseStorage.java
@@ -321,7 +321,7 @@ public final class DatabaseStorage extends VariablesStorage {
     }
 
     @SuppressWarnings("null")
-    private boolean connect(final boolean first) {
+    private final boolean connect(final boolean first) {
         synchronized (db) {
             // isConnected doesn't work in SQLite
 //			if (db.isConnected())
@@ -349,7 +349,7 @@ public final class DatabaseStorage extends VariablesStorage {
      *
      * @return True on success, false if an error is occurred and reported.
      */
-    private boolean prepareQueries() {
+    private final boolean prepareQueries() {
         synchronized (db) {
             final Database db = this.db.get();
             assert db != null;
@@ -503,7 +503,7 @@ public final class DatabaseStorage extends VariablesStorage {
     /**
      * Doesn't lock the database - {@link #save(String, String, byte[])} does that // what?
      */
-    private void loadVariables(final ResultSet r) throws SQLException {
+    private final void loadVariables(final ResultSet r) throws SQLException {
 //		assert !Thread.holdsLock(db);
 //		synchronized (syncDeserializing) {
 
@@ -589,7 +589,7 @@ public final class DatabaseStorage extends VariablesStorage {
      * @deprecated Only used for upgrading old variables/tables
      */
     @Deprecated
-    private void oldLoadVariables(final ResultSet r, final boolean hadNewTable) throws SQLException {
+    private final void oldLoadVariables(final ResultSet r, final boolean hadNewTable) throws SQLException {
 //		synchronized (oldSyncDeserializing) {
 
         final VariablesStorage temp = new OldVariablesStorage(databaseName);

--- a/src/main/java/ch/njol/skript/variables/FlatFileStorage.java
+++ b/src/main/java/ch/njol/skript/variables/FlatFileStorage.java
@@ -93,7 +93,7 @@ public final class FlatFileStorage extends VariablesStorage {
     }
 
     static final String encode(final byte[] data) {
-        final char[] r = new char[(data.length << 1)];
+        final char[] r = new char[data.length << 1];
         for (int i = 0; i < data.length; i++) {
             r[2 * i] = Character.toUpperCase(Character.forDigit((data[i] & 0xF0) >>> 4, 16));
             r[2 * i + 1] = Character.toUpperCase(Character.forDigit(data[i] & 0xF, 16));
@@ -143,7 +143,7 @@ public final class FlatFileStorage extends VariablesStorage {
     }
 
     /**
-     * Doesn'ts lock the connection as required by {@link Variables#variableLoaded(String, Object, VariablesStorage)}.
+     * Doesn't lock the connection as required by {@link Variables#variableLoaded(String, Object, VariablesStorage)}.
      */
     @SuppressWarnings({"deprecation", "unused", "null"})
     @Override

--- a/src/main/java/ch/njol/skript/variables/Variables.java
+++ b/src/main/java/ch/njol/skript/variables/Variables.java
@@ -115,8 +115,8 @@ public final class Variables {
                 init(); // separate method for the annotation
             }
 
-            @SuppressWarnings({"unchecked", "null", "cast"})
-            private void init() {
+            @SuppressWarnings({"unchecked", "null"})
+            private final void init() {
                 // used by asserts
                 info = (ClassInfo<? extends ConfigurationSerializable>) (ClassInfo<?>) Classes.getExactClassInfo(Object.class);
             }

--- a/src/main/java/ch/njol/yggdrasil/DefaultYggdrasilInputStream.java
+++ b/src/main/java/ch/njol/yggdrasil/DefaultYggdrasilInputStream.java
@@ -62,18 +62,18 @@ public final class DefaultYggdrasilInputStream extends YggdrasilInputStream {
     /**
      * @throws EOFException If the end of the stream is reached
      */
-    private int read() throws IOException {
+    private final int read() throws IOException {
         final int b = in.read();
         if (b < 0)
             throw new EOFException();
         return b;
     }
 
-    private void readFully(final byte[] buf) throws IOException {
+    private final void readFully(final byte[] buf) throws IOException {
         readFully(buf, 0, buf.length);
     }
 
-    private void readFully(final byte[] buf, int off, final int len) throws IOException {
+    private final void readFully(final byte[] buf, int off, final int len) throws IOException {
         int l = len;
         while (l > 0) {
             final int n = in.read(buf, off, l);
@@ -84,13 +84,13 @@ public final class DefaultYggdrasilInputStream extends YggdrasilInputStream {
         }
     }
 
-    private String readShortString() throws IOException {
+    private final String readShortString() throws IOException {
         final int length = read();
         if (length == (T_REFERENCE.tag & 0xFF)) {
             final int i = version <= 1 ? readInt() : readUnsignedInt();
             if (i < 0 || i > readShortStrings.size())
                 throw new StreamCorruptedException("Invalid short string reference " + i);
-            return "" + readShortStrings.get(i);
+            return readShortStrings.get(i);
         }
         final byte[] d = new byte[length];
         readFully(d);
@@ -103,7 +103,7 @@ public final class DefaultYggdrasilInputStream extends YggdrasilInputStream {
     // Tag
 
     @Override
-    protected Tag readTag() throws IOException {
+    protected final Tag readTag() throws IOException {
         final int t = read();
         final Tag tag = Tag.byID(t);
         if (tag == null)
@@ -113,49 +113,49 @@ public final class DefaultYggdrasilInputStream extends YggdrasilInputStream {
 
     // Primitives
 
-    private byte readByte() throws IOException {
+    private final byte readByte() throws IOException {
         return (byte) read();
     }
 
-    private short readShort() throws IOException {
+    private final short readShort() throws IOException {
         return (short) (read() << 8 | read());
     }
 
-    private short readUnsignedShort() throws IOException {
+    private final short readUnsignedShort() throws IOException {
         final int b = read();
         if ((b & 0x80) != 0)
             return (short) (b & ~0x80);
         return (short) (b << 8 | read());
     }
 
-    private int readInt() throws IOException {
+    private final int readInt() throws IOException {
         return read() << 24 | read() << 16 | read() << 8 | read();
     }
 
-    private int readUnsignedInt() throws IOException {
+    private final int readUnsignedInt() throws IOException {
         final int b = read();
         if ((b & 0x80) != 0)
             return (b & ~0x80) << 8 | read();
         return b << 24 | read() << 16 | read() << 8 | read();
     }
 
-    private long readLong() throws IOException {
+    private final long readLong() throws IOException {
         return (long) read() << 56 | (long) read() << 48 | (long) read() << 40 | (long) read() << 32 | (long) read() << 24 | read() << 16 | read() << 8 | read();
     }
 
-    private float readFloat() throws IOException {
+    private final float readFloat() throws IOException {
         return Float.intBitsToFloat(readInt());
     }
 
-    private double readDouble() throws IOException {
+    private final double readDouble() throws IOException {
         return Double.longBitsToDouble(readLong());
     }
 
-    private char readChar() throws IOException {
+    private final char readChar() throws IOException {
         return (char) readShort();
     }
 
-    private boolean readBoolean() throws IOException {
+    private final boolean readBoolean() throws IOException {
         final int r = read();
         if (r == 0)
             return false;
@@ -165,7 +165,7 @@ public final class DefaultYggdrasilInputStream extends YggdrasilInputStream {
     }
 
     @Override
-    protected Object readPrimitive(final Tag type) throws IOException {
+    protected final Object readPrimitive(final Tag type) throws IOException {
         switch (type) {
             case T_BYTE:
                 return readByte();
@@ -190,14 +190,14 @@ public final class DefaultYggdrasilInputStream extends YggdrasilInputStream {
     }
 
     @Override
-    protected Object readPrimitive_(final Tag type) throws IOException {
+    protected final Object readPrimitive_(final Tag type) throws IOException {
         return readPrimitive(type);
     }
 
     // String
 
     @Override
-    protected String readString() throws IOException {
+    protected final String readString() throws IOException {
         final int length = readUnsignedInt();
         final byte[] d = new byte[length];
         readFully(d);
@@ -207,24 +207,24 @@ public final class DefaultYggdrasilInputStream extends YggdrasilInputStream {
     // Array
 
     @Override
-    protected Class<?> readArrayComponentType() throws IOException {
+    protected final Class<?> readArrayComponentType() throws IOException {
         return readClass();
     }
 
     @Override
-    protected int readArrayLength() throws IOException {
+    protected final int readArrayLength() throws IOException {
         return readUnsignedInt();
     }
 
     // Enum
 
     @Override
-    protected Class<?> readEnumType() throws IOException {
+    protected final Class<?> readEnumType() throws IOException {
         return yggdrasil.getClass(readShortString());
     }
 
     @Override
-    protected String readEnumID() throws IOException {
+    protected final String readEnumID() throws IOException {
         return readShortString();
     }
 
@@ -232,7 +232,7 @@ public final class DefaultYggdrasilInputStream extends YggdrasilInputStream {
 
     @SuppressWarnings("null")
     @Override
-    protected Class<?> readClass() throws IOException {
+    protected final Class<?> readClass() throws IOException {
         Tag type;
         int dim = 0;
         while ((type = readTag()) == T_ARRAY)
@@ -280,34 +280,34 @@ public final class DefaultYggdrasilInputStream extends YggdrasilInputStream {
     // Reference
 
     @Override
-    protected int readReference() throws IOException {
+    protected final int readReference() throws IOException {
         return readUnsignedInt();
     }
 
     // generic Object
 
     @Override
-    protected Class<?> readObjectType() throws IOException {
+    protected final Class<?> readObjectType() throws IOException {
         return yggdrasil.getClass(readShortString());
     }
 
     @Override
-    protected short readNumFields() throws IOException {
+    protected final short readNumFields() throws IOException {
         return readUnsignedShort();
     }
 
     @Override
-    protected String readFieldID() throws IOException {
+    protected final String readFieldID() throws IOException {
         return readShortString();
     }
 
     // stream
 
     @Override
-    public void close() throws IOException {
+    public final void close() throws IOException {
         try {
             read();
-            throw new StreamCorruptedException("Stream still has data, at least " + (1 + in.available()) + " bytes remain");
+            throw new StreamCorruptedException("Stream still has data, at least " + (1 + in.available()) + " bytes remaining");
         } catch (final EOFException ignored) {
             /* ignored */
         } finally {

--- a/src/main/java/ch/njol/yggdrasil/DefaultYggdrasilOutputStream.java
+++ b/src/main/java/ch/njol/yggdrasil/DefaultYggdrasilOutputStream.java
@@ -33,7 +33,7 @@ public final class DefaultYggdrasilOutputStream extends YggdrasilOutputStream {
     private final OutputStream out;
 
     private final short version;
-    private final HashMap<String, Integer> writtenShortStrings = new HashMap<>();
+    private final HashMap<String, Integer> writtenShortStrings = new HashMap<>(100);
 
     // private
     int nextShortStringID;
@@ -46,19 +46,19 @@ public final class DefaultYggdrasilOutputStream extends YggdrasilOutputStream {
         writeShort(version);
     }
 
-    private void write(final int b) throws IOException {
+    private final void write(final int b) throws IOException {
         out.write(b);
     }
 
     @Override
-    protected void writeTag(final Tag t) throws IOException {
+    protected final void writeTag(final Tag t) throws IOException {
         out.write(t.tag);
     }
 
     /**
      * Writes a class ID or Field name
      */
-    private void writeShortString(final String s) throws IOException {
+    private final void writeShortString(final String s) throws IOException {
         if (writtenShortStrings.containsKey(s)) {
             writeTag(T_REFERENCE);
             if (version <= 1)
@@ -80,16 +80,16 @@ public final class DefaultYggdrasilOutputStream extends YggdrasilOutputStream {
 
     // Primitives
 
-    private void writeByte(final byte b) throws IOException {
+    private final void writeByte(final byte b) throws IOException {
         write(b & 0xFF);
     }
 
-    private void writeShort(final short s) throws IOException {
+    private final void writeShort(final short s) throws IOException {
         write(s >>> 8 & 0xFF);
         write(s & 0xFF);
     }
 
-    private void writeUnsignedShort(final short s) throws IOException {
+    private final void writeUnsignedShort(final short s) throws IOException {
         assert s >= 0;
         if (s <= 0x7f)
             writeByte((byte) (0x80 | s));
@@ -97,14 +97,14 @@ public final class DefaultYggdrasilOutputStream extends YggdrasilOutputStream {
             writeShort(s);
     }
 
-    private void writeInt(final int i) throws IOException {
+    private final void writeInt(final int i) throws IOException {
         write(i >>> 24 & 0xFF);
         write(i >>> 16 & 0xFF);
         write(i >>> 8 & 0xFF);
         write(i & 0xFF);
     }
 
-    private void writeUnsignedInt(final int i) throws IOException {
+    private final void writeUnsignedInt(final int i) throws IOException {
         assert i >= 0;
         if (i <= 0x7FFF)
             writeShort((short) (0x8000 | i));
@@ -112,7 +112,7 @@ public final class DefaultYggdrasilOutputStream extends YggdrasilOutputStream {
             writeInt(i);
     }
 
-    private void writeLong(final long l) throws IOException {
+    private final void writeLong(final long l) throws IOException {
         write((int) (l >>> 56 & 0xFF));
         write((int) (l >>> 48 & 0xFF));
         write((int) (l >>> 40 & 0xFF));
@@ -123,24 +123,24 @@ public final class DefaultYggdrasilOutputStream extends YggdrasilOutputStream {
         write((int) (l & 0xFF));
     }
 
-    private void writeFloat(final float f) throws IOException {
+    private final void writeFloat(final float f) throws IOException {
         writeInt(Float.floatToIntBits(f));
     }
 
-    private void writeDouble(final double d) throws IOException {
+    private final void writeDouble(final double d) throws IOException {
         writeLong(Double.doubleToLongBits(d));
     }
 
-    private void writeChar(final char c) throws IOException {
+    private final void writeChar(final char c) throws IOException {
         writeShort((short) c);
     }
 
-    private void writeBoolean(final boolean b) throws IOException {
+    private final void writeBoolean(final boolean b) throws IOException {
         write(b ? 1 : 0);
     }
 
     @Override
-    protected void writePrimitive_(final Object o) throws IOException {
+    protected final void writePrimitive_(final Object o) throws IOException {
         switch (getPrimitiveFromWrapper(o.getClass())) {
             case T_BYTE:
                 writeByte((Byte) o);
@@ -173,14 +173,14 @@ public final class DefaultYggdrasilOutputStream extends YggdrasilOutputStream {
     }
 
     @Override
-    protected void writePrimitiveValue(final Object o) throws IOException {
+    protected final void writePrimitiveValue(final Object o) throws IOException {
         writePrimitive_(o);
     }
 
     // String
 
     @Override
-    protected void writeStringValue(final String s) throws IOException {
+    protected final void writeStringValue(final String s) throws IOException {
         final byte[] d = s.getBytes(StandardCharsets.UTF_8);
         writeUnsignedInt(d.length);
         out.write(d);
@@ -189,29 +189,29 @@ public final class DefaultYggdrasilOutputStream extends YggdrasilOutputStream {
     // Array
 
     @Override
-    protected void writeArrayComponentType(final Class<?> componentType) throws IOException {
+    protected final void writeArrayComponentType(final Class<?> componentType) throws IOException {
         writeClass_(componentType);
     }
 
     @Override
-    protected void writeArrayLength(final int length) throws IOException {
+    protected final void writeArrayLength(final int length) throws IOException {
         writeUnsignedInt(length);
     }
 
     @Override
-    protected void writeArrayEnd() throws IOException {
+    protected final void writeArrayEnd() throws IOException {
         /* empty */
     }
 
     // Class
 
     @Override
-    protected void writeClassType(final Class<?> c) throws IOException {
+    protected final void writeClassType(final Class<?> c) throws IOException {
         writeClass_(c);
     }
 
     @SuppressWarnings("null")
-    private void writeClass_(Class<?> c) throws IOException {
+    private final void writeClass_(Class<?> c) throws IOException {
         while (c.isArray()) {
             writeTag(T_ARRAY);
             c = c.getComponentType();
@@ -247,60 +247,60 @@ public final class DefaultYggdrasilOutputStream extends YggdrasilOutputStream {
             case T_REFERENCE:
             case T_ARRAY:
             default:
-                throw new YggdrasilException("" + c.getCanonicalName());
+                throw new YggdrasilException(c.getCanonicalName());
         }
     }
 
     // Enum
 
     @Override
-    protected void writeEnumType(final String type) throws IOException {
+    protected final void writeEnumType(final String type) throws IOException {
         writeShortString(type);
     }
 
     @Override
-    protected void writeEnumID(final String id) throws IOException {
+    protected final void writeEnumID(final String id) throws IOException {
         writeShortString(id);
     }
 
     // generic Object
 
     @Override
-    protected void writeObjectType(final String type) throws IOException {
+    protected final void writeObjectType(final String type) throws IOException {
         writeShortString(type);
     }
 
     @Override
-    protected void writeNumFields(final short numFields) throws IOException {
+    protected final void writeNumFields(final short numFields) throws IOException {
         writeUnsignedShort(numFields);
     }
 
     @Override
-    protected void writeFieldID(final String id) throws IOException {
+    protected final void writeFieldID(final String id) throws IOException {
         writeShortString(id);
     }
 
     @Override
-    protected void writeObjectEnd() throws IOException {
+    protected final void writeObjectEnd() throws IOException {
         /* empty */
     }
 
     // Reference
 
     @Override
-    protected void writeReferenceID(final int ref) throws IOException {
+    protected final void writeReferenceID(final int ref) throws IOException {
         writeUnsignedInt(ref);
     }
 
     // stream
 
     @Override
-    public void flush() throws IOException {
+    public final void flush() throws IOException {
         out.flush();
     }
 
     @Override
-    public void close() throws IOException {
+    public final void close() throws IOException {
         out.close();
     }
 

--- a/src/main/java/ch/njol/yggdrasil/Fields.java
+++ b/src/main/java/ch/njol/yggdrasil/Fields.java
@@ -138,7 +138,7 @@ public final class Fields implements Iterable<FieldContext> {
      * @throws NotSerializableException
      * @throws YggdrasilException       If this was called on a Fields object not created by Yggdrasil itself
      */
-    public void setFields(final Object o) throws StreamCorruptedException, NotSerializableException {
+    public final void setFields(final Object o) throws StreamCorruptedException, NotSerializableException {
         final Yggdrasil y = yggdrasil;
         if (y == null)
             throw new YggdrasilException("");
@@ -187,7 +187,7 @@ public final class Fields implements Iterable<FieldContext> {
         c.setObject(value);
     }
 
-    public void putPrimitive(final String fieldID, final Object value) {
+    public final void putPrimitive(final String fieldID, final Object value) {
         FieldContext c = fields.get(fieldID);
         if (c == null)
             fields.put(fieldID, c = new FieldContext(fieldID));
@@ -366,7 +366,7 @@ public final class Fields implements Iterable<FieldContext> {
             return (T) value;
         }
 
-        public void setField(final Object o, final Field f, final Yggdrasil y) throws StreamCorruptedException {
+        public final void setField(final Object o, final Field f, final Yggdrasil y) throws StreamCorruptedException {
             if (Modifier.isStatic(f.getModifiers()))
                 throw new StreamCorruptedException("The field " + id + " of " + f.getDeclaringClass() + " is static");
             if (Modifier.isTransient(f.getModifiers()))

--- a/src/main/java/ch/njol/yggdrasil/JRESerializer.java
+++ b/src/main/java/ch/njol/yggdrasil/JRESerializer.java
@@ -118,11 +118,11 @@ public final class JRESerializer extends YggdrasilSerializer<Object> {
         throw new StreamCorruptedException();
     }
 
-    @SuppressWarnings({"unchecked", "cast", "null"})
+    @SuppressWarnings({"unchecked", "null"})
     @Override
     public <E> E deserialize(final Class<E> c, final Fields fields) throws StreamCorruptedException, NotSerializableException {
         if (c == UUID.class) {
-            return (E) new UUID(fields.getPrimitive("mostSigBits", Long.TYPE), fields.getPrimitive("leastSigBits", Long.TYPE));
+            return (E) new UUID(fields.getPrimitive("mostSigBits", long.class), fields.getPrimitive("leastSigBits", long.class));
         }
         throw new StreamCorruptedException();
     }

--- a/src/main/java/ch/njol/yggdrasil/Tag.java
+++ b/src/main/java/ch/njol/yggdrasil/Tag.java
@@ -106,14 +106,14 @@ public enum Tag {
     public final Class<?> c;
     public final String name;
 
-    Tag(final int tag, final @Nullable Class<?> c, final String name) {
+    Tag(final int tag, @Nullable final Class<?> c, final String name) {
         assert 0 <= tag && tag <= 0xFF : tag;
         this.tag = (byte) tag;
         this.c = c;
         this.name = name;
     }
 
-    public static final Tag getType(final @Nullable Class<?> c) {
+    public static final Tag getType(@Nullable final Class<?> c) {
         if (c == null)
             return T_NULL;
         final Tag t = types.get(c);

--- a/src/main/java/ch/njol/yggdrasil/Yggdrasil.java
+++ b/src/main/java/ch/njol/yggdrasil/Yggdrasil.java
@@ -147,7 +147,7 @@ public final class Yggdrasil {
         throw new StreamCorruptedException("Enum constant " + id + " does not exist in " + c);
     }
 
-    public YggdrasilOutputStream newOutputStream(final OutputStream out) throws IOException {
+    public final YggdrasilOutputStream newOutputStream(final OutputStream out) throws IOException {
         return new DefaultYggdrasilOutputStream(this, out);
     }
 
@@ -188,7 +188,7 @@ public final class Yggdrasil {
     }
 
     @Nullable
-    YggdrasilSerializer<?> getSerializer(final Class<?> c) {
+    final YggdrasilSerializer<?> getSerializer(final Class<?> c) {
         for (final ClassResolver r : classResolvers) {
             if (r instanceof YggdrasilSerializer && r.getID(c) != null)
                 return (YggdrasilSerializer<?>) r;
@@ -212,7 +212,7 @@ public final class Yggdrasil {
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Nullable
-    private String getIDNoError(Class<?> c) {
+    private final String getIDNoError(Class<?> c) {
         if (c == Object.class)
             return "Object";
         assert Tag.getType(c) == Tag.T_OBJECT || Tag.getType(c) == Tag.T_ENUM;

--- a/src/main/java/ch/njol/yggdrasil/YggdrasilInputStream.java
+++ b/src/main/java/ch/njol/yggdrasil/YggdrasilInputStream.java
@@ -65,7 +65,7 @@ public abstract class YggdrasilInputStream implements Closeable {
 
     // Enum
 
-    private void readArrayContents(final Object array) throws IOException {
+    private final void readArrayContents(final Object array) throws IOException {
         if (array.getClass().getComponentType().isPrimitive()) {
             final int length = Array.getLength(array);
             final Tag type = getType(array.getClass().getComponentType());
@@ -86,7 +86,7 @@ public abstract class YggdrasilInputStream implements Closeable {
     // Class
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    private Object readEnum() throws IOException {
+    private final Object readEnum() throws IOException {
         final Class<?> c = readEnumType();
         final String id = readEnumID();
         if (Enum.class.isAssignableFrom(c)) {
@@ -120,7 +120,7 @@ public abstract class YggdrasilInputStream implements Closeable {
 
     // any Objects
 
-    private Fields readFields() throws IOException {
+    private final Fields readFields() throws IOException {
         final Fields fields = new Fields(yggdrasil);
         final short numFields = readNumFields();
         for (int i = 0; i < numFields; i++) {
@@ -152,7 +152,7 @@ public abstract class YggdrasilInputStream implements Closeable {
 
     @SuppressWarnings({"rawtypes", "unchecked", "null", "unused"})
     @Nullable
-    private Object readObject(final Tag t) throws IOException {
+    private final Object readObject(final Tag t) throws IOException {
         if (t == T_NULL)
             return null;
         if (t == T_REFERENCE) {

--- a/src/main/java/ch/njol/yggdrasil/YggdrasilOutputStream.java
+++ b/src/main/java/ch/njol/yggdrasil/YggdrasilOutputStream.java
@@ -53,7 +53,7 @@ public abstract class YggdrasilOutputStream implements Flushable, Closeable {
 
     protected abstract void writeTag(Tag t) throws IOException;
 
-    private void writeNull() throws IOException {
+    private final void writeNull() throws IOException {
         writeTag(T_NULL);
     }
 
@@ -63,7 +63,7 @@ public abstract class YggdrasilOutputStream implements Flushable, Closeable {
 
     // String
 
-    private void writePrimitive(final Object o) throws IOException {
+    private final void writePrimitive(final Object o) throws IOException {
         final Tag t = getType(o.getClass());
         assert t.isWrapper();
         final Tag p = t.getPrimitive();
@@ -72,7 +72,7 @@ public abstract class YggdrasilOutputStream implements Flushable, Closeable {
         writePrimitiveValue(o);
     }
 
-    private void writeWrappedPrimitive(final Object o) throws IOException {
+    private final void writeWrappedPrimitive(final Object o) throws IOException {
         final Tag t = getType(o.getClass());
         assert t.isWrapper();
         writeTag(t);
@@ -83,7 +83,7 @@ public abstract class YggdrasilOutputStream implements Flushable, Closeable {
 
     protected abstract void writeStringValue(String s) throws IOException;
 
-    private void writeString(final String s) throws IOException {
+    private final void writeString(final String s) throws IOException {
         writeTag(T_STRING);
         writeStringValue(s);
     }
@@ -97,7 +97,7 @@ public abstract class YggdrasilOutputStream implements Flushable, Closeable {
     @SuppressWarnings("EmptyMethod")
     protected abstract void writeArrayEnd() throws IOException;
 
-    private void writeArray(final Object array) throws IOException {
+    private final void writeArray(final Object array) throws IOException {
         final int length = Array.getLength(array);
         final Class<?> ct = array.getClass().getComponentType();
         assert ct != null;
@@ -124,7 +124,7 @@ public abstract class YggdrasilOutputStream implements Flushable, Closeable {
 
     // Class
 
-    private void writeEnum(final Enum<?> o) throws IOException {
+    private final void writeEnum(final Enum<?> o) throws IOException {
         writeTag(T_ENUM);
         final Class<?> c = o.getDeclaringClass();
         assert c != null;
@@ -132,7 +132,7 @@ public abstract class YggdrasilOutputStream implements Flushable, Closeable {
         writeEnumID(Yggdrasil.getID(o));
     }
 
-    private void writeEnum(final PseudoEnum<?> o) throws IOException {
+    private final void writeEnum(final PseudoEnum<?> o) throws IOException {
         writeTag(T_ENUM);
         writeEnumType(yggdrasil.getID(o.getDeclaringClass()));
         writeEnumID(o.name());
@@ -142,7 +142,7 @@ public abstract class YggdrasilOutputStream implements Flushable, Closeable {
 
     protected abstract void writeClassType(Class<?> c) throws IOException;
 
-    private void writeClass(final Class<?> c) throws IOException {
+    private final void writeClass(final Class<?> c) throws IOException {
         writeTag(T_CLASS);
         writeClassType(c);
     }
@@ -169,7 +169,7 @@ public abstract class YggdrasilOutputStream implements Flushable, Closeable {
     protected abstract void writeObjectEnd() throws IOException;
 
     @SuppressWarnings({"rawtypes", "unchecked", "unused", "null"})
-    private void writeGenericObject(final Object o, int ref) throws IOException {
+    private final void writeGenericObject(final Object o, int ref) throws IOException {
         final Class<?> c = o.getClass();
         assert c != null;
         if (!yggdrasil.isSerializable(c))
@@ -210,7 +210,7 @@ public abstract class YggdrasilOutputStream implements Flushable, Closeable {
             writtenObjects.put(o, ~ref);
     }
 
-    public final void writeObject(final @Nullable Object o) throws IOException {
+    public final void writeObject(@Nullable final Object o) throws IOException {
         if (o == null) {
             writeNull();
             return;

--- a/src/main/java/ch/njol/yggdrasil/YggdrasilSerializable.java
+++ b/src/main/java/ch/njol/yggdrasil/YggdrasilSerializable.java
@@ -54,7 +54,7 @@ public interface YggdrasilSerializable {
          * <tt>yggdrasil.{@link Yggdrasil#incompatibleField(Object, Field, FieldContext) incompatibleField}(this, field, value)</tt> will be called.
          */
         @SuppressWarnings("null")
-        boolean incompatibleField(final @NonNull Field field, final @NonNull FieldContext value) throws StreamCorruptedException;
+        boolean incompatibleField(@NonNull final Field field, @NonNull final FieldContext value) throws StreamCorruptedException;
 
         /**
          * Called if a field was read from stream which does not exist in this class.
@@ -63,7 +63,7 @@ public interface YggdrasilSerializable {
          * @return Whatever the field was handled. If false, <tt>yggdrasil.{@link Yggdrasil#excessiveField(Object, FieldContext) excessiveField}(this, field)</tt> will be called.
          */
         @SuppressWarnings("null")
-        boolean excessiveField(final @NonNull FieldContext field) throws StreamCorruptedException;
+        boolean excessiveField(@NonNull final FieldContext field) throws StreamCorruptedException;
 
         /**
          * Called if a field was not found in the stream.
@@ -73,7 +73,7 @@ public interface YggdrasilSerializable {
          * <tt>yggdrasil.{@link Yggdrasil#missingField(Object, Field) missingField}(this, field)</tt> will be called.
          */
         @SuppressWarnings("null")
-        boolean missingField(final @NonNull Field field) throws StreamCorruptedException;
+        boolean missingField(@NonNull final Field field) throws StreamCorruptedException;
 
     }
 
@@ -130,7 +130,7 @@ public interface YggdrasilSerializable {
          * @throws NotSerializableException
          */
         @SuppressWarnings("null")
-        void deserialize(final @NonNull Fields fields) throws StreamCorruptedException, NotSerializableException;
+        void deserialize(@NonNull final Fields fields) throws StreamCorruptedException, NotSerializableException;
 
     }
 

--- a/src/main/java/ch/njol/yggdrasil/YggdrasilSerializer.java
+++ b/src/main/java/ch/njol/yggdrasil/YggdrasilSerializer.java
@@ -68,7 +68,7 @@ public abstract class YggdrasilSerializer<T> implements ClassResolver {
      * @return A new instance of the given class. Must not be null if {@link #canBeInstantiated(Class)} returned true.
      */
     @Nullable
-    public abstract <E extends T> E newInstance(Class<E> c);
+    public abstract <E extends T> E newInstance(final Class<E> c);
 
     /**
      * Deserialises an object.


### PR DESCRIPTION
# Changes made in this Pull Request
Removed an extra OfflinePlayer#getName call that caused Bukkit trying to get the player name from the world data, it slows down the variable saving a lot if you don't have a decent NVMe SSD.

# Reason of the above changes are
The OfflinePlayer#getName call is not required anyway, because we are already using UUIDs when supported.

We can do everything with just the UUID. Name is not required anymore unless you are using a very very outdated build of CB.

# Other information about this Pull Request
See also GH-82 for other informations about this topic and problem.