### PR TITLE
Fix SonarCloud JDK 8 warning

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,10 +21,10 @@ jobs:
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
 
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1.4.3
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Cache SonarCloud packages
         uses: actions/cache@v2.1.3

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -52,7 +52,6 @@ jobs:
           mvn install:install-file -Dfile=lib/worldguard-6.1.2.jar -DgroupId=com.sk89q -DartifactId=worldguard -Dversion=6.1.2 -Dpackaging=jar -DgeneratePom=true
           mvn install:install-file -Dfile=lib/worldedit-6.1.9.jar -DgroupId=com.sk89q -DartifactId=worldedit -Dversion=6.1.9 -Dpackaging=jar -DgeneratePom=true
           mvn -Duser.name="Skript Team" -Djava.awt.headless=true -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -Dsun.stderr.encoding=UTF-8 -Dsun.stdout.encoding=UTF-8 -Duser.language=en -Duser.country=US -Duser.timezone=Asia/Istanbul -DcompilerArgument=-O -e -B verify -U clean org.jacoco:jacoco-maven-plugin:prepare-agent install package org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
-          java -Duser.name="Skript Team" -Djava.awt.headless=true -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -Dsun.stderr.encoding=UTF-8 -Dsun.stdout.encoding=UTF-8 -Duser.language=en -Duser.country=US -Duser.timezone=Asia/Istanbul -jar lib/proguard.jar @Skript.pro
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
# Changes made in this Pull Request
Apparently JDK 8 was deprecated on SonarCloud, so we'll now build with JDK 11 on GitHub Actions.

# Reason of the above changes are
Deprecation of  the JDK 8 on SonarCloud and the warning on the build.

# Other information about this Pull Request
We will still use JDK 8 to build locally and use that in releases and this change will have no impact on JDK 8 compatibility.