### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -373,7 +373,7 @@
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
-            <version>1.6.2</version>
+            <version>1.7.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -397,7 +397,7 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-test-junit</artifactId>
-            <version>1.3.72</version>
+            <version>1.4.10</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -602,12 +602,15 @@
 
                         <javacOption>-O</javacOption>
 
-                        <javacOption>-release</javacOption>
+                        <javacOption>-source</javacOption>
                         <javacOption>8</javacOption>
+						
+						<javacOption>-target</javacOption>
+						<javacOption>8</javacOption>
                     </javacOptions>
                     <!-- Strictly define language and api version. -->
-                    <languageVersion>1.3</languageVersion>
-                    <apiVersion>1.3</apiVersion>
+                    <languageVersion>1.4</languageVersion>
+                    <apiVersion>1.4</apiVersion>
                     <!-- Hacky way to fix build warning in tests. -->
                     <annotationProcessors/>
                     <annotationProcessorPaths/>
@@ -621,12 +624,13 @@
                 <configuration>
                     <skipMain>false</skipMain>
                     <skip>false</skip>
-                    <release>8</release>
+                    <source>8</source>
+					<target>8</target>
                     <fork>true</fork>
                     <optimize>true</optimize>
                     <forceJavacCompilerUse>false</forceJavacCompilerUse>
                     <compilerId>eclipse</compilerId>
-                    <compilerVersion>13</compilerVersion>
+                    <compilerVersion>14</compilerVersion>
                     <compilerArgs>
                         <arg>-properties</arg>
                         <arg>.settings/org.eclipse.jdt.core.prefs</arg>
@@ -648,7 +652,7 @@
                     <dependency>
                         <groupId>org.codehaus.plexus</groupId>
                         <artifactId>plexus-compiler-eclipse</artifactId>
-                        <version>2.8.6</version>
+                        <version>2.8.8</version>
                         <exclusions>
                             <exclusion>
                                 <groupId>org.codehaus.plexus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -604,9 +604,9 @@
 
                         <javacOption>-source</javacOption>
                         <javacOption>8</javacOption>
-						
-						<javacOption>-target</javacOption>
-						<javacOption>8</javacOption>
+
+                        <javacOption>-target</javacOption>
+                        <javacOption>8</javacOption>
                     </javacOptions>
                     <!-- Strictly define language and api version. -->
                     <languageVersion>1.4</languageVersion>
@@ -625,7 +625,7 @@
                     <skipMain>false</skipMain>
                     <skip>false</skip>
                     <source>8</source>
-					<target>8</target>
+                    <target>8</target>
                     <fork>true</fork>
                     <optimize>true</optimize>
                     <forceJavacCompilerUse>false</forceJavacCompilerUse>


### PR DESCRIPTION
# Changes made in this Pull Request
Update some dependencies and fix build failures whilst updating them. This a replacement for these auto-opened bot upgrade PRs: #134 , #148 , and #179 .
Since they do not update all at once or doesn't change language and api version, the build fails.

There were also a compatibility problem with plexus eclipse compiler, it wasn't giving errors for release argument before, and now it gives. So we removed the release argument and added source and target instead, since release is only JDK 9+

# Reason of the above changes are
Build failing in auto-opened bot PRs.

# Other information about this Pull Request
This will close these PRs once merged: #134 , #148 , and #179 .